### PR TITLE
Fix NPE thrown when starting WebhookEventProvider

### DIFF
--- a/core/src/main/java/com/xatkit/core/platform/io/WebhookEventProvider.java
+++ b/core/src/main/java/com/xatkit/core/platform/io/WebhookEventProvider.java
@@ -48,8 +48,8 @@ public abstract class WebhookEventProvider<T extends RuntimePlatform, H extends 
      */
     @Override
     public void start(@NonNull Configuration configuration) {
-        super.start(configuration);
         this.restHandler = createRestHandler();
+        super.start(configuration);
     }
 
     /**


### PR DESCRIPTION
The _start_ method called in _WebhookEventProvider_ results in a _NullPointerException_ thrown because the _super.start_ method is called before the RestHandler is created.

Currently _WebhookEventProvider.start -> RuntimeEventProvider.start -> RuntimePlatform.startEventProvider -> XatkitServer.registerWebhookEventProvider -> XatkitServer.registerRestEndpoint(webhookEventProvider.getEndpointMethod(), webhookEventProvider.getEndpointURI(), **webhookEventProvider.getRestHandler()**)_. Rest handler is required to be non-null, but _webhookEventProvider.getRestHandler()_ returns null because _WebhookEventProvider_ has not created a rest handler yet.

To fix this move _this.restHandler = createRestHandler();_ before _super.start(configuration);_ in _WebhookEventProvider.start_.